### PR TITLE
Remove asset references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ $RECYCLE.BIN/
 /force-app/main/default/profiles/
 /IlluminatedCloud/Expression/OfflineSymbolTable.zip
 /src-pull/main
+/.localdev/

--- a/docs/src/markdoc/config.js
+++ b/docs/src/markdoc/config.js
@@ -7,7 +7,7 @@ const variables = {
   tags,
   nodes,
   variables: {
-    packageId: "04tRb000001TfwrIAC",
+    packageId: "04tRb000001iDH7IAM",
     componentPackageId: "04tRb0000012Mv8IAE",
     urlPrefix: IS_PROD ? "/expression" : "",
   }

--- a/expression-src/main/src/helpers/q/tests/QInMemoryDatabaseTest.cls
+++ b/expression-src/main/src/helpers/q/tests/QInMemoryDatabaseTest.cls
@@ -418,46 +418,6 @@ private class QInMemoryDatabaseTest {
     }
 
     @IsTest
-    static void canQueryUsingACondition_dateTimesThatAreEqual() {
-        Datetime dateTime1 = Datetime.newInstance(2020, 1, 1, 1, 1, 1);
-        Datetime dateTime2 = Datetime.newInstance(2020, 1, 1, 1, 1, 2);
-
-        Asset asset1 = new Asset(UptimeRecordStart = dateTime1);
-        Asset asset2 = new Asset(UptimeRecordStart = dateTime2);
-        db.doInsert(new List<Asset>{
-            asset1, asset2
-        });
-
-        Q query = new Q(Asset.SObjectType)
-            .add(Q.condition('UptimeRecordStart').equalsTo(dateTime1));
-
-        List<SObject> results = db.run(query);
-
-        Assert.areEqual(1, results.size());
-        Assert.areEqual(asset1, results[0]);
-    }
-
-    @IsTest
-    static void canQueryUsingACondition_dateTimesThatAreNotEqual() {
-        Datetime dateTime1 = Datetime.newInstance(2020, 1, 1, 1, 1, 1);
-        Datetime dateTime2 = Datetime.newInstance(2020, 1, 1, 1, 1, 2);
-
-        Asset asset1 = new Asset(UptimeRecordStart = dateTime1);
-        Asset asset2 = new Asset(UptimeRecordStart = dateTime2);
-        db.doInsert(new List<Asset>{
-            asset1, asset2
-        });
-
-        Q query = new Q(Asset.SObjectType)
-            .add(Q.condition('UptimeRecordStart').notEqualsTo(dateTime1));
-
-        List<SObject> results = db.run(query);
-
-        Assert.areEqual(1, results.size());
-        Assert.areEqual(asset2, results[0]);
-    }
-
-    @IsTest
     static void canQueryUsingACondition_lessThan() {
         Account account1 = new Account(Name = 'Test Account', NumberOfEmployees = 10);
         Account account2 = new Account(Name = 'Test Account 2', NumberOfEmployees = 20);

--- a/sfdx-project_packaging.json
+++ b/sfdx-project_packaging.json
@@ -4,7 +4,7 @@
       "path": "expression-src",
       "package": "Expression",
       "versionName": "Version 1.11",
-      "versionNumber": "1.11.0.NEXT",
+      "versionNumber": "1.12.0.NEXT",
       "default": false,
       "versionDescription": "Expression core language",
       "ancestorVersion": "HIGHEST"
@@ -40,6 +40,7 @@
     "Expression@1.8.0-2": "04tRb000001EM3JIAW",
     "Expression@1.9.0-1": "04tRb000001GNL3IAO",
     "Expression@1.10.0-1": "04tRb000001SS2PIAW",
-    "Expression@1.11.0-1": "04tRb000001TfwrIAC"
+    "Expression@1.11.0-1": "04tRb000001TfwrIAC",
+    "Expression@1.12.0-1": "04tRb000001iDH7IAM"
   }
 }


### PR DESCRIPTION
Removing references to the Asset object in tests since it might not be present in some orgs.