### PR TITLE
Function caching

### DIFF
--- a/docs/src/app/docs/declaring-functions/page.md
+++ b/docs/src/app/docs/declaring-functions/page.md
@@ -86,6 +86,35 @@ function as a parameter and calls it:
 fun callFunction(f) => f();
 ```
 
+## Caching
+
+The Expression language will cache the result of a function call, so if a function is called multiple times with the
+same
+arguments and is within the same context, the result will be cached and the function will not be re-evaluated.
+
+This can be usedful when you have an evaluation that is expensive to compute, such as a `Query` call, and you want to
+reuse the result multiple times within the same expression.
+
+```
+fun foo(n) => Query(Account(where: Name = n)[Name]);
+
+[...foo("ACME"), ...foo("ACME")]
+```
+
+In this example, the `foo` function will only be evaluated once for the `ACME` account, and the result will be reused
+for the second call. This means that a single query will be consumed from the Salesforce limits.
+
+### Disabling Caching
+
+Function caching can be disabled by using the `nocache` keyword after the `fun` keyword. This will force the function to
+be re-evaluated every time it is called, even if the arguments are the same.
+
+```
+fun nocache foo(n) => Query(Account(where: Name = n)[Name]);
+
+[...foo("ACME"), ...foo("ACME")]
+```
+
 ## Considerations
 
 - Names given to functions will superse any of the language's built-in functions. So if you declare a `sum` function,

--- a/expression-src/main/src/interpreter/Environment.cls
+++ b/expression-src/main/src/interpreter/Environment.cls
@@ -155,4 +155,13 @@ public with sharing class Environment {
 
     public class EnvironmentException extends Exception {
     }
+
+    public Boolean equals(Object obj) {
+        Environment other = (Environment) obj;
+        return parentEnvironment == other.parentEnvironment && context == other.context && variables.equals(other.variables);
+    }
+
+    public override Integer hashCode() {
+        return (parentEnvironment != null ? parentEnvironment.hashCode() : 0) ^ (context != null ? context.hashCode() : 0) ^ variables.hashCode();
+    }
 }

--- a/expression-src/main/src/interpreter/Expr.cls
+++ b/expression-src/main/src/interpreter/Expr.cls
@@ -49,6 +49,7 @@ public abstract class Expr {
         public final Token name;
         public final List<Token> parameters;
         public final Expr body;
+        private Map<Environment, Object> cachedValueForEnvironment = new Map<Environment, Object>();
 
         public FunctionDeclaration(Token name, List<Token> parameters, Expr body) {
             this.name = name;
@@ -74,6 +75,18 @@ public abstract class Expr {
 
         public Arity getArity() {
             return Arity.exactly(parameters.size());
+        }
+
+        public void cache(Environment env, Object cachedValue) {
+            cachedValueForEnvironment.put(env, cachedValue);
+        }
+
+        public Boolean isCachedForEnvironment(Environment env) {
+            return cachedValueForEnvironment.containsKey(env);
+        }
+
+        public Object getCachedValueForEnvironment(Environment env) {
+            return cachedValueForEnvironment.get(env);
         }
     }
 

--- a/expression-src/main/src/interpreter/Expr.cls
+++ b/expression-src/main/src/interpreter/Expr.cls
@@ -49,12 +49,14 @@ public abstract class Expr {
         public final Token name;
         public final List<Token> parameters;
         public final Expr body;
-        private Map<Environment, Object> cachedValueForEnvironment = new Map<Environment, Object>();
+        public final Boolean skipCache;
+        private final Map<Environment, Object> cachedValueForEnvironment = new Map<Environment, Object>();
 
-        public FunctionDeclaration(Token name, List<Token> parameters, Expr body) {
+        public FunctionDeclaration(Token name, List<Token> parameters, Expr body, Boolean skipCache) {
             this.name = name;
             this.parameters = parameters;
             this.body = body;
+            this.skipCache = skipCache;
         }
 
         public String functionName {
@@ -78,14 +80,23 @@ public abstract class Expr {
         }
 
         public void cache(Environment env, Object cachedValue) {
+            if (skipCache) {
+                return;
+            }
             cachedValueForEnvironment.put(env, cachedValue);
         }
 
         public Boolean isCachedForEnvironment(Environment env) {
+            if (skipCache) {
+                return false;
+            }
             return cachedValueForEnvironment.containsKey(env);
         }
 
         public Object getCachedValueForEnvironment(Environment env) {
+            if (skipCache) {
+                return null;
+            }
             return cachedValueForEnvironment.get(env);
         }
     }

--- a/expression-src/main/src/interpreter/FunctionCaller.cls
+++ b/expression-src/main/src/interpreter/FunctionCaller.cls
@@ -10,6 +10,7 @@ public abstract class FunctionCaller {
         if (env.hasFunction(function.functionName)) {
             return new FunctionDeclarationCaller(function);
         } else if (StandardFunction.functionExistsInStandardLibrary(function.functionName)) {
+            // TODO: Also cache standard functions
             return new StandardLibraryFunctionCaller(function);
         }
 
@@ -45,8 +46,14 @@ public abstract class FunctionCaller {
                 );
             }
 
+            if (functionDeclaration.isCachedForEnvironment(functionScopeEnvironment)) {
+                return functionDeclaration.getCachedValueForEnvironment(functionScopeEnvironment);
+            }
+
             Interpreter functionInterpreter = new Interpreter(functionScopeEnvironment);
-            return functionInterpreter.interpret(functionDeclaration.body);
+            Object value = functionInterpreter.interpret(functionDeclaration.body);
+            functionDeclaration.cache(functionScopeEnvironment, value);
+            return value;
         }
     }
 

--- a/expression-src/main/src/interpreter/FunctionCaller.cls
+++ b/expression-src/main/src/interpreter/FunctionCaller.cls
@@ -10,7 +10,6 @@ public abstract class FunctionCaller {
         if (env.hasFunction(function.functionName)) {
             return new FunctionDeclarationCaller(function);
         } else if (StandardFunction.functionExistsInStandardLibrary(function.functionName)) {
-            // TODO: Also cache standard functions
             return new StandardLibraryFunctionCaller(function);
         }
 

--- a/expression-src/main/src/interpreter/Parser.cls
+++ b/expression-src/main/src/interpreter/Parser.cls
@@ -26,6 +26,13 @@ public with sharing class Parser {
 
     private Expr functionDeclarationCheck() {
         if (match(TokenType.FUNCTION_KEYWORD)) {
+            Boolean skipCache = false;
+
+            // The fun keyword might be followed (optionally) by the nocache keyword
+            if (match(TokenType.NOCACHE_KEYWORD)) {
+                skipCache = true;
+            }
+
             Token name = consume(TokenType.IDENTIFIER, 'Expect function name.');
             consume(TokenType.LEFT_PAREN, 'Expect \'(\' after function name.');
             List<Token> parameters = new List<Token>();
@@ -42,7 +49,7 @@ public with sharing class Parser {
             consume(TokenType.FAT_ARROW, 'Expect \'=>\' before function body.');
             Expr body = expression();
             consume(TokenType.SEMICOLON, 'Expect \';\' after function body.');
-            return new Expr.FunctionDeclaration(name, parameters, body);
+            return new Expr.FunctionDeclaration(name, parameters, body, skipCache);
         }
         return orCheck();
     }
@@ -283,7 +290,7 @@ public with sharing class Parser {
                 if (match(TokenType.FAT_ARROW)) {
                     Expr body = expression();
                     // Pass null as the name since it's anonymous
-                    return new Expr.FunctionDeclaration(null, parameters, body);
+                    return new Expr.FunctionDeclaration(null, parameters, body, true);
                 }
             }
 

--- a/expression-src/main/src/interpreter/PipeResolver.cls
+++ b/expression-src/main/src/interpreter/PipeResolver.cls
@@ -181,7 +181,8 @@ public with sharing class PipeResolver implements Visitor {
         return new Expr.FunctionDeclaration(
             functionDeclaration.name,
             functionDeclaration.parameters,
-            resolvedBody
+            resolvedBody,
+            functionDeclaration.skipCache
         );
     }
 }

--- a/expression-src/main/src/interpreter/Scanner.cls
+++ b/expression-src/main/src/interpreter/Scanner.cls
@@ -17,6 +17,7 @@ public with sharing class Scanner {
         keywords.put('asc', TokenType.ASC_KEYWORD);
         keywords.put('desc', TokenType.DESC_KEYWORD);
         keywords.put('fun', TokenType.FUNCTION_KEYWORD);
+        keywords.put('nocache', TokenType.NOCACHE_KEYWORD);
     }
 
     public Scanner(String source) {

--- a/expression-src/main/src/interpreter/TokenType.cls
+++ b/expression-src/main/src/interpreter/TokenType.cls
@@ -34,7 +34,7 @@ public enum TokenType {
     ASC_KEYWORD, DESC_KEYWORD,
 
     // ----------------- Functions ----------------------
-    FUNCTION_KEYWORD, FAT_ARROW, SEMICOLON,
+    FUNCTION_KEYWORD, FAT_ARROW, SEMICOLON, NOCACHE_KEYWORD,
 
     // ----------------- EOF ----------------------
     EOF

--- a/expression-src/main/src/interpreter/tests/EnvironmentTest.cls
+++ b/expression-src/main/src/interpreter/tests/EnvironmentTest.cls
@@ -1,0 +1,44 @@
+@IsTest
+private class EnvironmentTest {
+    @IsTest
+    static void environmentsAreEqualWhenTheyHaveTheSameSObjectContext() {
+        SObject context = new Account(Name = 'Test');
+        Environment environment1 = new Environment(context);
+        Environment environment2 = new Environment(context);
+        Assert.areEqual(environment1, environment2);
+    }
+
+    @IsTest
+    static void environmentsAreNotEqualWhenTheyHaveDifferentSObjectContexts() {
+        SObject context1 = new Account(Name = 'Test');
+        SObject context2 = new Account(Name = 'Test2');
+        Environment environment1 = new Environment(context1);
+        Environment environment2 = new Environment(context2);
+        Assert.areNotEqual(environment1, environment2);
+    }
+
+    @IsTest
+    static void environmentsAreEqualWhenTheyHaveTheSameParentEnvironment() {
+        Environment parentEnvironment = new Environment();
+        Environment environment1 = new Environment(parentEnvironment);
+        Environment environment2 = new Environment(parentEnvironment);
+        Assert.areEqual(environment1, environment2);
+    }
+
+    @IsTest
+    static void environmentsAreNotEqualWhenTheyHaveDifferentParentEnvironments() {
+        Environment parentEnvironment1 = new Environment();
+        Environment environment1 = new Environment(parentEnvironment1);
+        Environment environment2 = new Environment((Environment) null);
+        Assert.areNotEqual(environment1, environment2);
+    }
+
+    @IsTest
+    static void environmentsAreEqualWhenTheyHaveTheSameVariables() {
+        Environment environment1 = new Environment();
+        environment1.define('name', 'value');
+        Environment environment2 = new Environment();
+        environment2.define('name', 'value');
+        Assert.areEqual(environment1, environment2);
+    }
+}

--- a/expression-src/main/src/interpreter/tests/EnvironmentTest.cls-meta.xml
+++ b/expression-src/main/src/interpreter/tests/EnvironmentTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>60.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/expression-src/spec/language/functions/FunctionDeclarationTest.cls
+++ b/expression-src/spec/language/functions/FunctionDeclarationTest.cls
@@ -142,4 +142,36 @@ private class FunctionDeclarationTest {
 
         Assert.areEqual(10, result);
     }
+
+    @IsTest
+    static void functionsAreCachedWhenTheyAreCalledWithTheSameEnvironment() {
+        insert new Account(Name = 'ACME');
+
+        Test.startTest();
+        String expression = 'fun foo(n) => Query(Account(where: Name = n));\n' +
+            '\n' +
+            '[...foo("ACME"), ...foo("ACME")]';
+        Test.stopTest();
+
+        Evaluator.run(expression);
+
+        Assert.areEqual(1, Limits.getQueries(), 'Only one query should have been consumed, ' +
+            'since the function was called with the same argument');
+    }
+
+    @IsTest
+    static void functionsAreNotCachedWhenTheyAreCalledWithDifferentEnvironments() {
+        insert new Account(Name = 'ACME');
+
+        Test.startTest();
+        String expression = 'fun foo(n) => Query(Account(where: Name = n));\n' +
+            '\n' +
+            '[...foo("ACME"), ...foo("Salesforce")]';
+        Test.stopTest();
+
+        Evaluator.run(expression);
+
+        Assert.areEqual(2, Limits.getQueries(), 'Two queries should have been consumed, ' +
+            'since the function was called with different arguments');
+    }
 }

--- a/expression-src/spec/language/functions/FunctionDeclarationTest.cls
+++ b/expression-src/spec/language/functions/FunctionDeclarationTest.cls
@@ -174,4 +174,20 @@ private class FunctionDeclarationTest {
         Assert.areEqual(2, Limits.getQueries(), 'Two queries should have been consumed, ' +
             'since the function was called with different arguments');
     }
+
+    @IsTest
+    static void functionsAreNotCachedWhenTheNoCacheKeywordIsUsed() {
+        insert new Account(Name = 'ACME');
+
+        Test.startTest();
+        String expression = 'fun nocache foo(n) => Query(Account(where: Name = n));\n' +
+            '\n' +
+            '[...foo("ACME"), ...foo("ACME")]';
+        Test.stopTest();
+
+        Evaluator.run(expression);
+
+        Assert.areEqual(2, Limits.getQueries(), 'Two queries should have been consumed, ' +
+            'since the function was called with the "nocache" keyword');
+    }
 }


### PR DESCRIPTION
Introduces caching to the function declaration functionality.

Function results are now cached by default when they are called with the same arguments. This can be turned off by using the `nocache` keyword.