### PR TITLE
Multi-formula record gather

### DIFF
--- a/docs/src/app/docs/api/miscellaneous/Evaluator/page.md
+++ b/docs/src/app/docs/api/miscellaneous/Evaluator/page.md
@@ -362,3 +362,41 @@ List<String> recordNames = (List<String)expression.Evaluator.run(
 
 System.assertEquals(new List<String>{'Example 1', 'Example 2'}, recordNames);
 ```
+
+---
+
+### `retrieveRecordForFormulas(recordId, formulas)`
+
+Analyzes multiple formulas and retrieves a record with all fields needed by those formulas. 
+This is useful when you need to query a record once with all required fields for multiple 
+formula evaluations, rather than letting each formula evaluation perform its own query.
+
+#### Signature
+```apex
+global static SObject retrieveRecordForFormulas(Id recordId, List<String> formulas)
+```
+
+#### Parameters
+| Name | Type | Description |
+|------|------|-------------|
+| recordId | Id | The Id of the record to retrieve |
+| formulas | List&lt;String&gt; | List of formulas to analyze |
+
+#### Return Type
+**SObject**
+
+SObject The record populated with all fields referenced in the formulas
+
+#### Example
+```apex
+Id accountId = [SELECT Id FROM Account LIMIT 1].Id;
+List<String> formulas = new List<String>{
+  'Name',
+  'BillingCity',
+  'Owner.Name'
+};
+Account account = (Account)expression.Evaluator.retrieveRecordForFormulas(accountId, formulas);
+// Now use the account record which contains all the needed fields
+String accountName = (String)account.get('Name');
+String ownerName = (String)account.getSObject('Owner').get('Name');
+```

--- a/expression-src/main/api/Evaluator.cls
+++ b/expression-src/main/api/Evaluator.cls
@@ -222,4 +222,29 @@ global with sharing abstract class Evaluator {
     global static Object run(String formula, Set<Id> recordIds, Configuration config) {
         return EvaluatorResolver.forIds(recordIds).evaluate(formula, config).result;
     }
+    
+    /**
+     * @description Analyzes multiple formulas and retrieves a record with all fields needed by those formulas.
+     *              This is useful when you need to query a record once with all required fields for multiple
+     *              formula evaluations, rather than letting each formula evaluation perform its own query.
+     * @param recordId The Id of the record to retrieve
+     * @param formulas List of formulas to analyze
+     * @return SObject The record populated with all fields referenced in the formulas
+     * @example
+     * ```apex
+     * Id accountId = [SELECT Id FROM Account LIMIT 1].Id;
+     * List<String> formulas = new List<String>{
+     *   'Name',
+     *   'BillingCity',
+     *   'Owner.Name'
+     * };
+     * Account account = (Account)expression.Evaluator.retrieveRecordForFormulas(accountId, formulas);
+     * // Now use the account record which contains all the needed fields
+     * String accountName = (String)account.get('Name');
+     * String ownerName = (String)account.getSObject('Owner').get('Name');
+     * ```
+     */
+    global static SObject retrieveRecordForFormulas(Id recordId, List<String> formulas) {
+        return EvaluatorResolver.retrieveRecordForFormulas(recordId, formulas);
+    }
 }

--- a/expression-src/main/api/tests/EvaluatorRetrieveRecordTest.cls
+++ b/expression-src/main/api/tests/EvaluatorRetrieveRecordTest.cls
@@ -2,14 +2,13 @@
 private class EvaluatorRetrieveRecordTest {
     @IsTest
     static void testRetrieveRecordForFormulas() {
-        // Setup test data
         Account testAccount = new Account(
             Name = 'Test Account',
             BillingStreet = '123 Test Street',
             BillingCity = 'Test City',
-            BillingState = 'TS',
+            BillingState = 'Washington',
             BillingPostalCode = '12345',
-            BillingCountry = 'Test Country',
+            BillingCountry = 'United States',
             Phone = '555-1234'
         );
         insert testAccount;
@@ -23,22 +22,19 @@ private class EvaluatorRetrieveRecordTest {
         );
         insert testContact;
         
-        // Create list of formulas that reference various fields
         List<String> formulas = new List<String>{
-            'Name', // Simple field reference
-            'BillingCity', // Another simple field reference
-            'Phone', // Another field from the same object
-            'Name + " in " + BillingCity', // Formula with multiple field references
-            'Contacts[0].FirstName', // Child relationship field reference
-            'Contacts[0].FirstName + " " + Contacts[0].LastName' // More complex relationship reference
+            'Name',
+            'BillingCity',
+            'Phone',
+            'Name + " in " + BillingCity',
+            'MAP(Contacts, FirstName) -> FIRST()',
+            'MAP(Contacts, FirstName) -> FIRST() + " " + MAP(Contacts, LastName) -> FIRST()'
         };
         
-        // Call the method being tested
         Test.startTest();
         SObject result = Evaluator.retrieveRecordForFormulas(testAccount.Id, formulas);
         Test.stopTest();
         
-        // Verify the result
         System.assertNotEquals(null, result, 'Should have retrieved a record');
         
         Account retrievedAccount = (Account)result;
@@ -47,7 +43,6 @@ private class EvaluatorRetrieveRecordTest {
         System.assertEquals('Test City', retrievedAccount.BillingCity, 'BillingCity should be retrieved');
         System.assertEquals('555-1234', retrievedAccount.Phone, 'Phone should be retrieved');
         
-        // Check for child relationship data
         System.assertNotEquals(null, retrievedAccount.getSObjects('Contacts'), 'Should have retrieved contacts');
         System.assertEquals(1, retrievedAccount.getSObjects('Contacts').size(), 'Should have retrieved one contact');
         System.assertEquals('Test', retrievedAccount.getSObjects('Contacts')[0].get('FirstName'), 'Contact FirstName should be retrieved');
@@ -56,7 +51,6 @@ private class EvaluatorRetrieveRecordTest {
     
     @IsTest
     static void testRetrieveRecordWithRelationshipFields() {
-        // Setup test data with a related object
         User testUser = [SELECT Id, Name FROM User WHERE Id = :UserInfo.getUserId()];
         
         Account testAccount = new Account(
@@ -65,50 +59,41 @@ private class EvaluatorRetrieveRecordTest {
         );
         insert testAccount;
         
-        // Create formulas that include relationship fields
         List<String> formulas = new List<String>{
-            'Owner.Name', // Basic relationship field
-            'Owner.Name + " owns " + Name', // Using relationship field in a formula
+            'Owner.Name + " owns " + Name',
             'Name'
         };
         
-        // Call the method being tested
         Test.startTest();
         SObject result = Evaluator.retrieveRecordForFormulas(testAccount.Id, formulas);
         Test.stopTest();
         
-        // Verify the result
         System.assertNotEquals(null, result, 'Should have retrieved a record');
         
         Account retrievedAccount = (Account)result;
         System.assertEquals(testAccount.Id, retrievedAccount.Id, 'Should retrieve the correct account');
         System.assertEquals('Relationship Test Account', retrievedAccount.Name, 'Name should be retrieved');
         
-        // Check for relationship field data
         System.assertNotEquals(null, retrievedAccount.getSObject('Owner'), 'Should have retrieved Owner');
         System.assertEquals(testUser.Name, retrievedAccount.getSObject('Owner').get('Name'), 'Owner Name should be retrieved');
     }
     
     @IsTest
     static void testRetrieveRecordWithInvalidFormula() {
-        // Setup test data
         Account testAccount = new Account(Name = 'Error Test Account');
         insert testAccount;
         
-        // Create formulas with some valid and some invalid expressions
         List<String> formulas = new List<String>{
-            'Name', // Valid
-            'ThisFieldDoesNotExist', // Invalid field reference
-            'InvalidFunction(Name)', // Invalid function
-            'BillingCity' // Valid
+            'Name',
+            'ThisFieldDoesNotExist',
+            'InvalidFunction(Name)',
+            'BillingCity'
         };
         
-        // Call the method being tested
         Test.startTest();
         SObject result = Evaluator.retrieveRecordForFormulas(testAccount.Id, formulas);
         Test.stopTest();
         
-        // Verify that we still get results with the valid fields
         System.assertNotEquals(null, result, 'Should have retrieved a record despite some invalid formulas');
         
         Account retrievedAccount = (Account)result;
@@ -118,20 +103,16 @@ private class EvaluatorRetrieveRecordTest {
     
     @IsTest
     static void testRetrieveRecordWithEmptyOrNullInputs() {
-        // Setup test data
         Account testAccount = new Account(Name = 'Null Test Account');
         insert testAccount;
         
-        // Test with null formulas
         Test.startTest();
         SObject resultWithNullFormulas = Evaluator.retrieveRecordForFormulas(testAccount.Id, null);
         System.assertEquals(null, resultWithNullFormulas, 'Should return null with null formulas');
         
-        // Test with empty formulas list
         SObject resultWithEmptyFormulas = Evaluator.retrieveRecordForFormulas(testAccount.Id, new List<String>());
         System.assertEquals(null, resultWithEmptyFormulas, 'Should return null with empty formulas');
         
-        // Test with null recordId
         SObject resultWithNullId = Evaluator.retrieveRecordForFormulas(null, new List<String>{'Name'});
         System.assertEquals(null, resultWithNullId, 'Should return null with null recordId');
         Test.stopTest();

--- a/expression-src/main/api/tests/EvaluatorRetrieveRecordTest.cls
+++ b/expression-src/main/api/tests/EvaluatorRetrieveRecordTest.cls
@@ -1,0 +1,139 @@
+@IsTest
+private class EvaluatorRetrieveRecordTest {
+    @IsTest
+    static void testRetrieveRecordForFormulas() {
+        // Setup test data
+        Account testAccount = new Account(
+            Name = 'Test Account',
+            BillingStreet = '123 Test Street',
+            BillingCity = 'Test City',
+            BillingState = 'TS',
+            BillingPostalCode = '12345',
+            BillingCountry = 'Test Country',
+            Phone = '555-1234'
+        );
+        insert testAccount;
+        
+        Contact testContact = new Contact(
+            FirstName = 'Test',
+            LastName = 'Contact',
+            AccountId = testAccount.Id,
+            Email = 'test@example.com',
+            Phone = '555-5678'
+        );
+        insert testContact;
+        
+        // Create list of formulas that reference various fields
+        List<String> formulas = new List<String>{
+            'Name', // Simple field reference
+            'BillingCity', // Another simple field reference
+            'Phone', // Another field from the same object
+            'Name + " in " + BillingCity', // Formula with multiple field references
+            'Contacts[0].FirstName', // Child relationship field reference
+            'Contacts[0].FirstName + " " + Contacts[0].LastName' // More complex relationship reference
+        };
+        
+        // Call the method being tested
+        Test.startTest();
+        SObject result = Evaluator.retrieveRecordForFormulas(testAccount.Id, formulas);
+        Test.stopTest();
+        
+        // Verify the result
+        System.assertNotEquals(null, result, 'Should have retrieved a record');
+        
+        Account retrievedAccount = (Account)result;
+        System.assertEquals(testAccount.Id, retrievedAccount.Id, 'Should retrieve the correct account');
+        System.assertEquals('Test Account', retrievedAccount.Name, 'Name should be retrieved');
+        System.assertEquals('Test City', retrievedAccount.BillingCity, 'BillingCity should be retrieved');
+        System.assertEquals('555-1234', retrievedAccount.Phone, 'Phone should be retrieved');
+        
+        // Check for child relationship data
+        System.assertNotEquals(null, retrievedAccount.getSObjects('Contacts'), 'Should have retrieved contacts');
+        System.assertEquals(1, retrievedAccount.getSObjects('Contacts').size(), 'Should have retrieved one contact');
+        System.assertEquals('Test', retrievedAccount.getSObjects('Contacts')[0].get('FirstName'), 'Contact FirstName should be retrieved');
+        System.assertEquals('Contact', retrievedAccount.getSObjects('Contacts')[0].get('LastName'), 'Contact LastName should be retrieved');
+    }
+    
+    @IsTest
+    static void testRetrieveRecordWithRelationshipFields() {
+        // Setup test data with a related object
+        User testUser = [SELECT Id, Name FROM User WHERE Id = :UserInfo.getUserId()];
+        
+        Account testAccount = new Account(
+            Name = 'Relationship Test Account',
+            OwnerId = testUser.Id
+        );
+        insert testAccount;
+        
+        // Create formulas that include relationship fields
+        List<String> formulas = new List<String>{
+            'Owner.Name', // Basic relationship field
+            'Owner.Name + " owns " + Name', // Using relationship field in a formula
+            'Name'
+        };
+        
+        // Call the method being tested
+        Test.startTest();
+        SObject result = Evaluator.retrieveRecordForFormulas(testAccount.Id, formulas);
+        Test.stopTest();
+        
+        // Verify the result
+        System.assertNotEquals(null, result, 'Should have retrieved a record');
+        
+        Account retrievedAccount = (Account)result;
+        System.assertEquals(testAccount.Id, retrievedAccount.Id, 'Should retrieve the correct account');
+        System.assertEquals('Relationship Test Account', retrievedAccount.Name, 'Name should be retrieved');
+        
+        // Check for relationship field data
+        System.assertNotEquals(null, retrievedAccount.getSObject('Owner'), 'Should have retrieved Owner');
+        System.assertEquals(testUser.Name, retrievedAccount.getSObject('Owner').get('Name'), 'Owner Name should be retrieved');
+    }
+    
+    @IsTest
+    static void testRetrieveRecordWithInvalidFormula() {
+        // Setup test data
+        Account testAccount = new Account(Name = 'Error Test Account');
+        insert testAccount;
+        
+        // Create formulas with some valid and some invalid expressions
+        List<String> formulas = new List<String>{
+            'Name', // Valid
+            'ThisFieldDoesNotExist', // Invalid field reference
+            'InvalidFunction(Name)', // Invalid function
+            'BillingCity' // Valid
+        };
+        
+        // Call the method being tested
+        Test.startTest();
+        SObject result = Evaluator.retrieveRecordForFormulas(testAccount.Id, formulas);
+        Test.stopTest();
+        
+        // Verify that we still get results with the valid fields
+        System.assertNotEquals(null, result, 'Should have retrieved a record despite some invalid formulas');
+        
+        Account retrievedAccount = (Account)result;
+        System.assertEquals(testAccount.Id, retrievedAccount.Id, 'Should retrieve the correct account');
+        System.assertEquals('Error Test Account', retrievedAccount.Name, 'Name should be retrieved');
+    }
+    
+    @IsTest
+    static void testRetrieveRecordWithEmptyOrNullInputs() {
+        // Setup test data
+        Account testAccount = new Account(Name = 'Null Test Account');
+        insert testAccount;
+        
+        // Test with null formulas
+        Test.startTest();
+        SObject resultWithNullFormulas = Evaluator.retrieveRecordForFormulas(testAccount.Id, null);
+        System.assertEquals(null, resultWithNullFormulas, 'Should return null with null formulas');
+        
+        // Test with empty formulas list
+        SObject resultWithEmptyFormulas = Evaluator.retrieveRecordForFormulas(testAccount.Id, new List<String>());
+        System.assertEquals(null, resultWithEmptyFormulas, 'Should return null with empty formulas');
+        
+        // Test with null recordId
+        SObject resultWithNullId = Evaluator.retrieveRecordForFormulas(null, new List<String>{'Name'});
+        System.assertEquals(null, resultWithNullId, 'Should return null with null recordId');
+        Test.stopTest();
+    }
+}

--- a/expression-src/main/api/tests/EvaluatorRetrieveRecordTest.cls-meta.xml
+++ b/expression-src/main/api/tests/EvaluatorRetrieveRecordTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>60.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/expression-src/main/src/interpreter/ContextResolver.cls
+++ b/expression-src/main/src/interpreter/ContextResolver.cls
@@ -21,6 +21,39 @@ public with sharing class ContextResolver implements Visitor {
     private Object resolve(Expr expr) {
         return expr.accept(this);
     }
+    
+    /**
+     * @description Resolves an expression for record field references without building the query
+     * @param expression The expression to analyze
+     * @return Object The result of the visitor
+     */
+    public Object resolveForRecord(Expr expression) {
+        return this.resolve(expression);
+    }
+    
+    /**
+     * @description Checks if the query should be executed based on whether any fields were added to the query
+     * @return Boolean True if the query should be executed, false otherwise
+     */
+    public Boolean shouldExecuteQuery() {
+        return this.shouldExecuteQuery;
+    }
+    
+    /**
+     * @description Gets the current query context
+     * @return Query The current query context
+     */
+    public Query getQueryContext() {
+        return this.queryContext;
+    }
+    
+    /**
+     * @description Gets the list of subqueries that were added during expression resolution
+     * @return List<Query> The list of subqueries
+     */
+    public List<Query> getSubQueries() {
+        return this.subQueries;
+    }
 
     public List<SObject> build(Expr expression) {
         this.resolve(expression);

--- a/expression-src/main/src/resolver/EvaluatorResolver.cls
+++ b/expression-src/main/src/resolver/EvaluatorResolver.cls
@@ -25,6 +25,51 @@ public with sharing abstract class EvaluatorResolver {
     public static EvaluatorResolver withoutContext() {
         return new BaseSingleRecordEvaluator(null);
     }
+    
+    /**
+     * @description Analyzes multiple formulas and retrieves a record with all fields needed by those formulas
+     * @param recordId The Id of the record to retrieve
+     * @param formulas List of formulas to analyze
+     * @return SObject The record populated with all fields referenced by the formulas
+     */
+    public static SObject retrieveRecordForFormulas(Id recordId, List<String> formulas) {
+        if (recordId == null || formulas == null || formulas.isEmpty()) {
+            return null;
+        }
+        
+        ContextResolver contextResolver = new ContextResolver(recordId, new List<Expr.FunctionDeclaration>());
+        
+        for (String formula : formulas) {
+            try {
+                List<Token> tokens = new Scanner(formula).scanTokens();
+                List<Expr> expressions = new Parser(tokens).parse();
+                
+                for (Expr parsedExpression : expressions) {
+                    Expr desugaredExpression = new PipeResolver().resolve(parsedExpression);
+                    contextResolver.resolveForRecord(desugaredExpression);
+                }
+            } catch (Exception e) {
+                // Continue analyzing other formulas even if one fails
+                System.debug(LoggingLevel.WARN, 'Error analyzing formula "' + formula + '": ' + e.getMessage());
+            }
+        }
+        
+        if (!contextResolver.shouldExecuteQuery()) {
+            return null;
+        }
+        
+        // Add subqueries to the main query
+        for (ContextResolver.Query subquery : contextResolver.getSubQueries()) {
+            contextResolver.getQueryContext().queryBuilder.addSubquery(subquery.queryBuilder);
+        }
+        
+        // Add condition to filter by the specific record id
+        contextResolver.getQueryContext().queryBuilder.add(Q.condition('Id').isIn(new List<Id>{recordId}));
+        
+        // Execute the query and return the first record (if any)
+        List<SObject> records = QDB.getInstance().run(contextResolver.getQueryContext().queryBuilder);
+        return records.isEmpty() ? null : records[0];
+    }
 
     public EvaluationResult evaluate(String input, Configuration config) {
         config.subscribe(this.eventNotifier);


### PR DESCRIPTION
This PR introduces a new function that accepts a list of expressions/formulas and returns a single consolidated record containing all the necessary fields for evaluating each formula. This enables the use of a single SOQL query to fetch data, while still allowing multiple formulas to be evaluated later using the existing run(formula, record) method.