### PR TITLE
Fixing issue where running the evaluator multiple times with an expre…

### DIFF
--- a/docs/public/packages.json
+++ b/docs/public/packages.json
@@ -1,4 +1,4 @@
 {
-  "packageId": "04tRb0000036fbRIAQ",
+  "packageId": "04tRb0000036iJBIAY",
   "componentPackageId": "04tRb0000012Mv8IAE"
 }

--- a/expression-src/main/src/interpreter/Environment.cls
+++ b/expression-src/main/src/interpreter/Environment.cls
@@ -174,4 +174,11 @@ public with sharing class Environment {
     public override Integer hashCode() {
         return (parentEnvironment != null ? parentEnvironment.hashCode() : 0) ^ (context != null ? context.hashCode() : 0) ^ variables.hashCode();
     }
+
+    public class ClearContext implements EvaluatorEventListener {
+        public Map<String, Object> handle(EvaluatorEvent event) {
+            GLOBAL_VARIABLES.clear();
+            return null;
+        }
+    }
 }

--- a/expression-src/main/src/resolver/EvaluatorResolver.cls
+++ b/expression-src/main/src/resolver/EvaluatorResolver.cls
@@ -25,7 +25,7 @@ public with sharing abstract class EvaluatorResolver {
     public static EvaluatorResolver withoutContext() {
         return new BaseSingleRecordEvaluator(null);
     }
-    
+
     /**
      * @description Analyzes multiple formulas and retrieves a record with all fields needed by those formulas
      * @param recordId The Id of the record to retrieve
@@ -36,14 +36,14 @@ public with sharing abstract class EvaluatorResolver {
         if (recordId == null || formulas == null || formulas.isEmpty()) {
             return null;
         }
-        
+
         ContextResolver contextResolver = new ContextResolver(recordId, new List<Expr.FunctionDeclaration>());
-        
+
         for (String formula : formulas) {
             try {
                 List<Token> tokens = new Scanner(formula).scanTokens();
                 List<Expr> expressions = new Parser(tokens).parse();
-                
+
                 for (Expr parsedExpression : expressions) {
                     Expr desugaredExpression = new PipeResolver().resolve(parsedExpression);
                     contextResolver.resolveForRecord(desugaredExpression);
@@ -53,19 +53,19 @@ public with sharing abstract class EvaluatorResolver {
                 System.debug(LoggingLevel.WARN, 'Error analyzing formula "' + formula + '": ' + e.getMessage());
             }
         }
-        
+
         if (!contextResolver.shouldExecuteQuery()) {
             return null;
         }
-        
+
         // Add subqueries to the main query
         for (ContextResolver.Query subquery : contextResolver.getSubQueries()) {
             contextResolver.getQueryContext().queryBuilder.addSubquery(subquery.queryBuilder);
         }
-        
+
         // Add condition to filter by the specific record id
         contextResolver.getQueryContext().queryBuilder.add(Q.condition('Id').isIn(new List<Id>{recordId}));
-        
+
         // Execute the query and return the first record (if any)
         List<SObject> records = QDB.getInstance().run(contextResolver.getQueryContext().queryBuilder);
         return records.isEmpty() ? null : records[0];
@@ -73,6 +73,7 @@ public with sharing abstract class EvaluatorResolver {
 
     public EvaluationResult evaluate(String input, Configuration config) {
         config.subscribe(this.eventNotifier);
+        eventNotifier.subscribe(OnEvaluationEndEvent.class, new Environment.ClearContext());
 
         eventNotifier.notify(new OnEvaluationStartEvent(config));
 

--- a/expression-src/spec/language/functions/FunctionDeclarationTest.cls
+++ b/expression-src/spec/language/functions/FunctionDeclarationTest.cls
@@ -205,4 +205,20 @@ private class FunctionDeclarationTest {
         Assert.areEqual(2, Limits.getQueries(), 'Two queries should have been consumed, ' +
             'since the function was called with the "nocache" keyword');
     }
+
+    @IsTest
+    static void canRunEvaluatorMultipleTimesWhenUsingFunctions() {
+        insert new Account(Name = 'ACME');
+
+        String expression = 'fun foo(n) => Query(Account(where: Name = n));\n' +
+            '\n' +
+            '[...foo("ACME"), ...foo("Salesforce")]';
+
+        try {
+            Evaluator.run(expression);
+            Evaluator.run(expression);
+        } catch (Exception e) {
+            Assert.fail('Should be able to run the evaluator multiple times: ' + e.getMessage());
+        }
+    }
 }

--- a/sfdx-project_packaging.json
+++ b/sfdx-project_packaging.json
@@ -3,8 +3,8 @@
     {
       "path": "expression-src",
       "package": "Expression",
-      "versionName": "Version 1.29",
-      "versionNumber": "1.29.0.NEXT",
+      "versionName": "Version 1.3",
+      "versionNumber": "1.30.0.NEXT",
       "default": false,
       "versionDescription": "Expression core language",
       "ancestorVersion": "HIGHEST"
@@ -58,6 +58,7 @@
     "Expression@1.26.0-2": "04tRb0000034ahVIAQ",
     "Expression@1.27.0-2": "04tRb0000034eMvIAI",
     "Expression@1.28.0-2": "04tRb0000036OFdIAM",
-    "Expression@1.29.0-2": "04tRb0000036fbRIAQ"
+    "Expression@1.29.0-2": "04tRb0000036fbRIAQ",
+    "Expression@1.30.0-2": "04tRb0000036iJBIAY"
   }
 }


### PR DESCRIPTION
…ssion with functions errored out.

On the second run, the evaluator tried to use the same global context that was declared by the first one.

The global context is now cleared after every evaluation.