### PR TITLE
Suppress Errors In Run Config

### DIFF
--- a/expression-src/main/editor/staticresources/monaco/main.html
+++ b/expression-src/main/editor/staticresources/monaco/main.html
@@ -111,10 +111,28 @@
           [/(^#.*$)/, 'comment'],
 
           // strings
-          [/"/, 'string', '@string_double']
+          [/"/, 'string', '@string_double'],
+          [/"/, 'string', '@string_curved_left'],
+          [/"/, 'string', '@string_curved_right']
         ],
 
         string_double: [
+          [/\$\{/, { token: 'delimiter.bracket', next: '@bracketCounting' }],
+          [/[^\\"$]+/, 'string'],
+          [/@escapes/, 'string.escape'],
+          [/\\./, 'string.escape.invalid'],
+          [/"/, 'string', '@pop']
+        ],
+
+        string_curved_left: [
+          [/\$\{/, { token: 'delimiter.bracket', next: '@bracketCounting' }],
+          [/[^\\"$]+/, 'string'],
+          [/@escapes/, 'string.escape'],
+          [/\\./, 'string.escape.invalid'],
+          [/"/, 'string', '@pop']
+        ],
+
+        string_curved_right: [
           [/\$\{/, { token: 'delimiter.bracket', next: '@bracketCounting' }],
           [/[^\\"$]+/, 'string'],
           [/@escapes/, 'string.escape'],

--- a/expression-src/main/src/interpreter/Scanner.cls
+++ b/expression-src/main/src/interpreter/Scanner.cls
@@ -22,7 +22,12 @@ public with sharing class Scanner {
     }
 
     public Scanner(String source) {
-        this.source = source;
+        this.source = normalizeCurvedQuotes(source);
+    }
+
+    private String normalizeCurvedQuotes(String input) {
+        if (input == null) return null;
+        return input.replace('“', '"').replace('”', '"');
     }
 
     public List<Token> scanTokens() {


### PR DESCRIPTION
I am finding that it would be very useful to have a way to return blank values when there is an Error instead of returning that Error. For example, I am using expressions in many of my LWC components and am needing to either:

Use more complicated Expressions all over, for example, to check blanks to and return blanks

Build logic into each LWC to handle the errors.


I would be great to be able to simply add this into the configuration of the evaluator to handle this in one consolidated place.


Also, I did a very simple example implementation. I am simply doing a try-catch and haven't looked into if it should be done through the existing error logic. I just want to get the conversation going!