### PR TITLE
Enabling font ligatures in the Expression editor

### DIFF
--- a/expression-src/main/editor/staticresources/monaco/main.html
+++ b/expression-src/main/editor/staticresources/monaco/main.html
@@ -7,19 +7,20 @@
     data-name="vs/editor/editor.main"
     href="min/vs/editor/editor.main.css"
   />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Fira+Code&display=swap">
 </head>
 <body style="margin: 0;">
 <div id="container" style="height: 100vh;"></div>
 
 <script>
-  var require = {paths: {vs: 'min/vs'}};
+  var require = { paths: { vs: 'min/vs' } };
 </script>
 <script src="min/vs/loader.js"></script>
 <script src="min/vs/editor/editor.main.nls.js"></script>
 <script src="min/vs/editor/editor.main.js"></script>
 
 <script>
-  window.addEventListener("message", onMessage, false);
+  window.addEventListener('message', onMessage, false);
 
   function onMessage(event) {
     if (event.data.name === 'initialize') {
@@ -37,7 +38,7 @@
   }
 
   function initialize(functionKeywords, initialValue) {
-    monaco.languages.register({id: 'expression'});
+    monaco.languages.register({ id: 'expression' });
     let keywords = functionKeywords;
 
     monaco.languages.setLanguageConfiguration('expression', {
@@ -50,23 +51,23 @@
         ['(', ')'],
       ],
       autoClosingPairs: [
-        {open: '{', close: '}'},
-        {open: '[', close: ']'},
-        {open: '(', close: ')'},
-        {open: '"', close: '"', notIn: ['string']},
-        {open: "'", close: "'", notIn: ['string', 'comment']},
+        { open: '{', close: '}' },
+        { open: '[', close: ']' },
+        { open: '(', close: ')' },
+        { open: '"', close: '"', notIn: ['string'] },
+        { open: '\'', close: '\'', notIn: ['string', 'comment'] },
       ],
       surroundingPairs: [
-        {open: '{', close: '}'},
-        {open: '[', close: ']'},
-        {open: '(', close: ')'},
-        {open: '"', close: '"'},
-        {open: "'", close: "'"},
+        { open: '{', close: '}' },
+        { open: '[', close: ']' },
+        { open: '(', close: ')' },
+        { open: '"', close: '"' },
+        { open: '\'', close: '\'' },
       ],
       folding: {
         markers: {
-          start: new RegExp("^\\s*#region\\b"),
-          end: new RegExp("^\\s*#endregion\\b")
+          start: new RegExp('^\\s*#region\\b'),
+          end: new RegExp('^\\s*#endregion\\b')
         }
       }
     });
@@ -86,7 +87,7 @@
       tokenizer: {
         root: [
           [/[{}]/, 'delimiter.bracket'],
-          {include: 'common'},
+          { include: 'common' },
         ],
 
         common: [
@@ -114,7 +115,7 @@
         ],
 
         string_double: [
-          [/\$\{/, {token: 'delimiter.bracket', next: '@bracketCounting'}],
+          [/\$\{/, { token: 'delimiter.bracket', next: '@bracketCounting' }],
           [/[^\\"$]+/, 'string'],
           [/@escapes/, 'string.escape'],
           [/\\./, 'string.escape.invalid'],
@@ -124,7 +125,7 @@
         bracketCounting: [
           [/\{/, 'delimiter.bracket', '@bracketCounting'],
           [/\}/, 'delimiter.bracket', '@pop'],
-          {include: 'common'}
+          { include: 'common' }
         ]
       },
       ignoreCase: true
@@ -138,22 +139,24 @@
                 label: k,
                 kind: monaco.languages.CompletionItemKind.Keyword,
                 insertText: k,
-              }
+              };
             }
           )
         ];
-        return {suggestions: suggestions};
+        return { suggestions: suggestions };
       }
     });
 
     window.editor = monaco.editor.create(document.getElementById('container'), {
       value: initialValue ?? [''].join('\n'),
       language: 'expression',
-      wordWrap: "wordWrapColumn",
+      wordWrap: 'wordWrapColumn',
       wordWrapColumn: 100,
       minimap: {
         enabled: false
       },
+      fontLigatures: true,
+      fontFamily: 'Fira Code, monospace'
     });
 
     window.editor.getModel().onDidChangeContent((event) => {
@@ -167,7 +170,7 @@
   }
 
   function clearMarkers() {
-    monaco.editor.setModelMarkers(window.editor.getModel(), "owner", []);
+    monaco.editor.setModelMarkers(window.editor.getModel(), 'owner', []);
   }
 
   function markError(error) {
@@ -179,18 +182,18 @@
       endColumn: error.endColumnNumber,
       message: error.summary,
       severity: monaco.MarkerSeverity.Error
-    })
+    });
 
-    monaco.editor.setModelMarkers(window.editor.getModel(), "owner", markers);
+    monaco.editor.setModelMarkers(window.editor.getModel(), 'owner', markers);
   }
 
   function appendText(text) {
     // Append function to the end of the editor.
     // If there is a selection, replace it with the function.
     const selection = editor.getSelection();
-    const id = {major: 1, minor: 1};
-    const op = {identifier: id, range: selection, text: text, forceMoveMarkers: true};
-    editor.executeEdits("my-source", [op]);
+    const id = { major: 1, minor: 1 };
+    const op = { identifier: id, range: selection, text: text, forceMoveMarkers: true };
+    editor.executeEdits('my-source', [op]);
   }
 
   function getParentOrigin() {


### PR DESCRIPTION
Enables font ligatures in the editor, to improve the way that piped code looks

<img width="196" height="102" alt="image" src="https://github.com/user-attachments/assets/c9d36c1d-f8b8-4581-8dc0-c47a2a04d5ed" />
