### PR TITLE
Fix permission namespace handling

### DIFF
--- a/cirrus.toml
+++ b/cirrus.toml
@@ -8,10 +8,10 @@ deploy = "sf project deploy start"
 assign-perms = "sf org assign permset -n Expression_Admin"
 test = "sf apex test run --test-level RunLocalTests --wait 20"
 docs = "apexdocs markdown"
-generate-library-docs = "node scripts/generate-library-docs.mjs"
-prep-package = "node scripts/prepare-for-packaging.mjs"
+generate-library-docs = "bun scripts/generate-library-docs.mjs"
+prep-package = "bun scripts/prepare-for-packaging.mjs"
 package = "cirrus package -p Expression -t minor -x -c --promote -w 60"
-post-package = "node scripts/post-packaging.mjs"
+post-package = "bun scripts/post-packaging.mjs"
 
 [flow.start-dev]
 description = "Starts a new development environment"

--- a/docs/public/packages.json
+++ b/docs/public/packages.json
@@ -1,4 +1,4 @@
 {
-  "packageId": "04tRb000003NrEnIAK",
+  "packageId": "04tRb000003UxfFIAS",
   "componentPackageId": "04tRb0000012Mv8IAE"
 }

--- a/docs/src/app/docs/referencing-org-data/page.md
+++ b/docs/src/app/docs/referencing-org-data/page.md
@@ -95,8 +95,23 @@ Available references are:
 
 ## Permission
 
+{% callout type="warning" %}
+Due to limitations with calling `FeatureManagement.checkPermission` from within a managed package, Expression
+checks permissions by querying the `CustomPermission` and `SetupEntityAccess` objects. 
+
+This means that each permission check will consume 2 SOQL queries the first time it is evaluated (checks are
+cached afterwards).
+{% /callout %}
+
 Allows you to reference information about the current user’s custom permission access.
 
 ```
 $Permission.MyCustomPermissionName # Returns true if the user has access to the custom permission, false otherwise.
+```
+
+To reference a custom permission that has a namespace, separate the namespace and the permission name with double
+underscores (`__`):
+
+```
+$Permission.namespace__MyCustomPermissionName # Returns true if the user has access to the custom permission, false otherwise.
 ```

--- a/expression-src/main/src/interpreter/variable-resolvers/PermissionVariableResolver.cls
+++ b/expression-src/main/src/interpreter/variable-resolvers/PermissionVariableResolver.cls
@@ -1,5 +1,47 @@
 public with sharing class PermissionVariableResolver implements IGlobalVariableResolver {
+    private static final Map<String, Boolean> permissionCache = new Map<String, Boolean>();
     public Object get(String referenceName, List<Object> args) {
-        return FeatureManagement.checkPermission(referenceName);
+        if (permissionCache.containsKey(referenceName)) {
+            return permissionCache.get(referenceName);
+        }
+
+        List<String> namespacePermissionParts = referenceName.split('__');
+
+        String permissionName = referenceName;
+        String namespacePrefix = '';
+        // Custom permission name can come in 2 flavors, namespace__PermissionName or just PermissionName.
+        if (namespacePermissionParts.size() > 1) {
+            namespacePrefix = namespacePermissionParts[0];
+            permissionName = namespacePermissionParts[1];
+        }
+
+        List<CustomPermission> customPermissions = [
+                SELECT Id, DeveloperName
+                FROM CustomPermission
+                WHERE DeveloperName = :permissionName
+                AND NamespacePrefix = :namespacePrefix
+        ];
+
+        if (customPermissions.size() != 1) {
+            permissionCache.put(referenceName, false);
+            return false;
+        }
+
+        Map<Id, CustomPermission> customPermissionNamesById = new Map<Id, CustomPermission>(customPermissions);
+
+        List<SetupEntityAccess> setupEntities = [
+                SELECT SetupEntityId
+                FROM SetupEntityAccess
+                WHERE SetupEntityId IN :customPermissionNamesById.keySet() AND
+                ParentId IN (
+                        SELECT PermissionSetId
+                        FROM PermissionSetAssignment
+                        WHERE AssigneeId = :UserInfo.getUserId()
+                )
+        ];
+
+        Boolean result = !setupEntities.isEmpty();
+        permissionCache.put(referenceName, result);
+        return result;
     }
 }

--- a/sfdx-project_packaging.json
+++ b/sfdx-project_packaging.json
@@ -4,7 +4,7 @@
       "path": "expression-src",
       "package": "Expression",
       "versionName": "Version 1.36",
-      "versionNumber": "1.39.0.NEXT",
+      "versionNumber": "1.40.0.NEXT",
       "default": false,
       "versionDescription": "Expression core language",
       "ancestorVersion": "HIGHEST"
@@ -68,6 +68,7 @@
     "Expression@1.36.0-1": "04tRb000003NrEnIAK",
     "Expression@1.37.0-3": "04tRb000003OmWPIA0",
     "Expression@1.38.0-1": "04tRb000003R4nNIAS",
-    "Expression@1.39.0-1": "04tRb000003R51tIAC"
+    "Expression@1.39.0-1": "04tRb000003R51tIAC",
+    "Expression@1.40.0-1": "04tRb000003UxfFIAS"
   }
 }


### PR DESCRIPTION
There are limitations with calling FeatureManagement.checkPermission, thus the `$Permission` global variable implementation was refactored to use SOQL queries instead, based on this https://andyinthecloud.com/2015/01/14/creating-assigning-and-checking-custom-permissions/