### PR TITLE
Added Curved Quotation handling to scanner and Monaco Static Resource

### DIFF
--- a/expression-src/main/editor/staticresources/monaco/main.html
+++ b/expression-src/main/editor/staticresources/monaco/main.html
@@ -111,7 +111,9 @@
           [/(^#.*$)/, 'comment'],
 
           // strings
-          [/"/, 'string', '@string_double']
+          [/"/, 'string', '@string_double'],
+          [/“/, 'string', '@string_curved_left'],
+          [/”/, 'string', '@string_curved_right']
         ],
 
         string_double: [
@@ -120,6 +122,22 @@
           [/@escapes/, 'string.escape'],
           [/\\./, 'string.escape.invalid'],
           [/"/, 'string', '@pop']
+        ],
+
+        string_curved_left: [
+          [/\$\{/, { token: 'delimiter.bracket', next: '@bracketCounting' }],
+          [/[^\\"$]+/, 'string'],
+          [/@escapes/, 'string.escape'],
+          [/\\./, 'string.escape.invalid'],
+          [/“/, 'string', '@pop']
+        ],
+
+        string_curved_right: [
+          [/\$\{/, { token: 'delimiter.bracket', next: '@bracketCounting' }],
+          [/[^\\"$]+/, 'string'],
+          [/@escapes/, 'string.escape'],
+          [/\\./, 'string.escape.invalid'],
+          [/”/, 'string', '@pop']
         ],
 
         bracketCounting: [

--- a/expression-src/main/src/interpreter/Scanner.cls
+++ b/expression-src/main/src/interpreter/Scanner.cls
@@ -22,7 +22,12 @@ public with sharing class Scanner {
     }
 
     public Scanner(String source) {
-        this.source = source;
+        this.source = normalizeCurvedQuotes(source);
+    }
+
+    private String normalizeCurvedQuotes(String input) {
+        if (input == null) return null;
+        return input.replace('“', '"').replace('”', '"');
     }
 
     public List<Token> scanTokens() {


### PR DESCRIPTION
Recently I have been running into issues where some platforms, namely google, automatically choose to use curved/curly/smart quotations when typing quotation marks. This is very hard to catch ahead of time when a user is doing things like copy/pasting from google. I have made some simple replacements where I thought would be necessary! Let me know of any concerns!