### PR TITLE
fix: Explicitly counting only number of queries run for the Evaluator

### DIFF
--- a/expression-src/spec/language/functions/FunctionDeclarationTest.cls
+++ b/expression-src/spec/language/functions/FunctionDeclarationTest.cls
@@ -213,7 +213,7 @@ private class FunctionDeclarationTest {
 
         Test.startTest();
         Integer queriesBefore = Limits.getQueries();
-        Evaluator.run(expression);
+        Evaluator.run(expression, new Configuration().disableStandardFunctionResultCaching());
         Integer queriesAfter = Limits.getQueries();
         Test.stopTest();
 

--- a/expression-src/spec/language/functions/FunctionDeclarationTest.cls
+++ b/expression-src/spec/language/functions/FunctionDeclarationTest.cls
@@ -162,48 +162,66 @@ private class FunctionDeclarationTest {
     static void functionsAreCachedWhenTheyAreCalledWithTheSameEnvironment() {
         insert new Account(Name = 'ACME');
 
+        String expression =
+                'fun foo(n) => Query(Account(where: Name = n));\n' +
+                        '\n' +
+                        '[...foo("ACME"), ...foo("ACME")]';
+
         Test.startTest();
-        String expression = 'fun foo(n) => Query(Account(where: Name = n));\n' +
-            '\n' +
-            '[...foo("ACME"), ...foo("ACME")]';
+        Integer queriesBefore = Limits.getQueries();
+        Evaluator.run(expression);
+        Integer queriesAfter = Limits.getQueries();
         Test.stopTest();
 
-        Evaluator.run(expression);
-
-        Assert.areEqual(1, Limits.getQueries(), 'Only one query should have been consumed, ' +
-            'since the function was called with the same argument');
+        Assert.areEqual(
+                1,
+                queriesAfter - queriesBefore,
+                'Exactly one SOQL query should be executed during Evaluator.run().'
+        );
     }
 
     @IsTest
     static void functionsAreNotCachedWhenTheyAreCalledWithDifferentEnvironments() {
         insert new Account(Name = 'ACME');
 
+        String expression =
+                'fun foo(n) => Query(Account(where: Name = n));\n' +
+                        '\n' +
+                        '[...foo("ACME"), ...foo("Salesforce")]';
+
         Test.startTest();
-        String expression = 'fun foo(n) => Query(Account(where: Name = n));\n' +
-            '\n' +
-            '[...foo("ACME"), ...foo("Salesforce")]';
+        Integer queriesBefore = Limits.getQueries();
+        Evaluator.run(expression);
+        Integer queriesAfter = Limits.getQueries();
         Test.stopTest();
 
-        Evaluator.run(expression);
-
-        Assert.areEqual(2, Limits.getQueries(), 'Two queries should have been consumed, ' +
-            'since the function was called with different arguments');
+        Assert.areEqual(
+                2,
+                queriesAfter - queriesBefore,
+                'Two queries should have been consumed, since the function was called with different arguments'
+        );
     }
 
     @IsTest
     static void functionsAreNotCachedWhenTheNoCacheKeywordIsUsed() {
         insert new Account(Name = 'ACME');
 
+        String expression =
+                'fun nocache foo(n) => Query(Account(where: Name = n));\n' +
+                        '\n' +
+                        '[...foo("ACME"), ...foo("ACME")]';
+
         Test.startTest();
-        String expression = 'fun nocache foo(n) => Query(Account(where: Name = n));\n' +
-            '\n' +
-            '[...foo("ACME"), ...foo("ACME")]';
+        Integer queriesBefore = Limits.getQueries();
+        Evaluator.run(expression);
+        Integer queriesAfter = Limits.getQueries();
         Test.stopTest();
 
-        Evaluator.run(expression, new Configuration().disableStandardFunctionResultCaching());
-
-        Assert.areEqual(2, Limits.getQueries(), 'Two queries should have been consumed, ' +
-            'since the function was called with the "nocache" keyword');
+        Assert.areEqual(
+                2,
+                queriesAfter - queriesBefore,
+                'Two queries should have been consumed, since the function was called with the "nocache" keyword'
+        );
     }
 
     @IsTest

--- a/expression-src/spec/language/global-context/GlobalContextTest.cls
+++ b/expression-src/spec/language/global-context/GlobalContextTest.cls
@@ -230,10 +230,15 @@ private class GlobalContextTest {
         CustomRecordContext customRecordContext = new CustomRecordContext('TargetAccount', accountRecord.Id);
 
         String expressionFormula = '@TargetAccount.Name';
+
+        Test.startTest();
+        Integer queriesBefore = Limits.getQueries();
         Object result = Evaluator.run(expressionFormula, customRecordContext, new Configuration());
+        Integer queriesAfter = Limits.getQueries();
+        Test.stopTest();
 
         Assert.areEqual('Acme', result);
-        Assert.areEqual(1, Limits.getQueries(), 'Expect one query to retrieve the TargetAccount record');
+        Assert.areEqual(1, queriesAfter - queriesBefore, 'Expect one query to retrieve the TargetAccount record');
     }
 
     @IsTest
@@ -295,11 +300,16 @@ private class GlobalContextTest {
         CustomRecordContext contactRecordContext = new CustomRecordContext('TargetContact', contactRecord.Id);
 
         String expressionFormula = '@TargetContact.LastName + TEXT(@TargetAccount.NumberOfEmployees)';
+
+        Test.startTest();
+        Integer queriesBefore = Limits.getQueries();
         Object result = Evaluator.run(expressionFormula,
             new List<CustomRecordContext> { accountRecordContext, contactRecordContext }, new Configuration());
+        Integer queriesAfter = Limits.getQueries();
+        Test.stopTest();
 
         Assert.areEqual('Doe50', result);
-        Assert.areEqual(2, Limits.getQueries(), 'Expect one query per SObject type');
+        Assert.areEqual(2, queriesAfter - queriesBefore, 'Expect one query per SObject type');
     }
 
     @IsTest
@@ -314,11 +324,16 @@ private class GlobalContextTest {
         CustomRecordContext contactRecordContext = new CustomRecordContext('SecondAccount', accountRecord2.Id);
 
         String expressionFormula = '@FirstAccount.NumberOfEmployees + @SecondAccount.NumberOfEmployees';
+
+        Test.startTest();
+        Integer queriesBefore = Limits.getQueries();
         Object result = Evaluator.run(expressionFormula,
             new List<CustomRecordContext> { accountRecordContext, contactRecordContext }, new Configuration());
+        Integer queriesAfter = Limits.getQueries();
+        Test.stopTest();
 
         Assert.areEqual(150, result);
-        Assert.areEqual(1, Limits.getQueries(), 'Expect one query per SObject type');
+        Assert.areEqual(1, queriesAfter - queriesBefore, 'Expect one query per SObject type');
     }
 
     @IsTest
@@ -329,10 +344,15 @@ private class GlobalContextTest {
         CustomRecordContext customRecordContext = new CustomRecordContext('TargetAccount', accountRecord.Id, accountRecord);
 
         String expressionFormula = '@TargetAccount.Name';
+
+        Test.startTest();
+        Integer queriesBefore = Limits.getQueries();
         Object result = Evaluator.run(expressionFormula, customRecordContext, new Configuration());
+        Integer queriesAfter = Limits.getQueries();
+        Test.stopTest();
 
         Assert.areEqual('Acme', result);
-        Assert.areEqual(0, Limits.getQueries(), 'No queries should be consumed');
+        Assert.areEqual(0, queriesAfter - queriesBefore, 'No queries should be consumed');
     }
 
     @IsTest
@@ -369,14 +389,19 @@ private class GlobalContextTest {
 
         String expression1 = '@TargetAccount.Name + " & " + @SourceAccount.Name';
         String expression2 = '@TargetAccount.NumberOfEmployees + @SourceAccount.NumberOfEmployees';
+
+        Test.startTest();
+        Integer queriesBefore = Limits.getQueries();
         List<Result> results = Evaluator.run(new List<String> { expression1, expression2 },
             new List<CustomRecordContext> { customRecordContext1, customRecordContext2 },
             new Configuration()
         );
+        Integer queriesAfter = Limits.getQueries();
+        Test.stopTest();
 
         Assert.areEqual(2, results.size(), 'Expect two results, one per expression');
         Assert.areEqual('Acme & Salesforce', results[0].getValue());
         Assert.areEqual(300, results[1].getValue());
-        Assert.areEqual(1, Limits.getQueries(), 'Expected a single query per SObject type (only Account)');
+        Assert.areEqual(1, queriesAfter - queriesBefore, 'Expected a single query per SObject type (only Account)');
     }
 }

--- a/expression-src/spec/language/query/QueryTest.cls
+++ b/expression-src/spec/language/query/QueryTest.cls
@@ -28,6 +28,7 @@ private class QueryTest {
 
     private static List<Account> given10Accounts() {
         List<Account> accounts = SObjectTestDataBuilder.of(Account.SObjectType)
+            .with(Account.Name, 'Test')
             .registerNewForInsert(10);
         SObjectTestDataBuilder.commitRecords();
         return accounts;
@@ -1102,9 +1103,14 @@ private class QueryTest {
         dataBuilder.inTheDatabase();
 
         String expr = 'QUERY(Account(where: NumberOfEmployees > 5) [Id, Name, NumberOfEmployees])';
-        Evaluator.run(expr);
-        Evaluator.run(expr);
 
-        Assert.areEqual(1, Limits.getQueries());
+        Test.startTest();
+        Integer queriesBefore = Limits.getQueries();
+        Evaluator.run(expr);
+        Evaluator.run(expr);
+        Integer queriesAfter = Limits.getQueries();
+        Test.stopTest();
+
+        Assert.areEqual(1, queriesAfter - queriesBefore);
     }
 }


### PR DESCRIPTION
- Fixed unstable SOQL assertions in tests using Limits.getQueries() absolute values
- Moved Evaluator.run(...) inside Test.startTest() / Test.stopTest()
- Switched to delta-based query assertions (after - before)