### PR TITLE
fix: caching: resetting global static variable for each run, fixed ac…

### DIFF
--- a/expression-src/main/src/interpreter/EnvironmentCache.cls
+++ b/expression-src/main/src/interpreter/EnvironmentCache.cls
@@ -10,12 +10,16 @@ public with sharing class EnvironmentCache {
         isStandardFunctionCacheDisabled = true;
     }
 
+    public static void enableCache() {
+        isStandardFunctionCacheDisabled = false;
+    }
+
     public static void cacheStandardFunctionCall(
         Environment env,
         Expr.FunctionCall function,
         Object result
     ) {
-        cacheFunctionCall(isStandardFunctionCacheDisabled, env, function, result);
+        cacheFunctionCall(!isStandardFunctionCacheDisabled, env, function, result);
     }
 
     public static void cacheCustomMetadataFunctionCall(

--- a/expression-src/main/src/interpreter/tests/EvaluatorCustomContextCacheTest.cls
+++ b/expression-src/main/src/interpreter/tests/EvaluatorCustomContextCacheTest.cls
@@ -1,0 +1,35 @@
+@IsTest
+private class EvaluatorCustomContextCacheTest {
+
+    @IsTest
+    static void standardFunctionCacheDisabled_doesNotReuseFirstCustomContext() {
+        Configuration config1 = new Configuration();
+        config1.cacheStandardFunctionResults = false;
+        config1.customContext = new Map<String, Object>{
+                'value' => 'first'
+        };
+
+        Configuration config2 = new Configuration();
+        config2.cacheStandardFunctionResults = false;
+        config2.customContext = new Map<String, Object>{
+                'value' => 'second'
+        };
+
+        Test.startTest();
+        Object firstResult = Evaluator.run('UPPER(@value)', config1);
+        Object secondResult = Evaluator.run('UPPER(@value)', config2);
+        Test.stopTest();
+
+        System.assertEquals(
+                'FIRST',
+                firstResult,
+                'First evaluation must use the first customContext, not cached result from first run.'
+        );
+        System.assertEquals(
+                'SECOND',
+                secondResult,
+                'Second evaluation must use the second customContext, not cached result from first run.'
+        );
+    }
+
+}

--- a/expression-src/main/src/interpreter/tests/EvaluatorCustomContextCacheTest.cls-meta.xml
+++ b/expression-src/main/src/interpreter/tests/EvaluatorCustomContextCacheTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/expression-src/main/src/resolver/EvaluatorResolver.cls
+++ b/expression-src/main/src/resolver/EvaluatorResolver.cls
@@ -87,7 +87,9 @@ public with sharing abstract class EvaluatorResolver {
         eventNotifier.notify(new OnEvaluationStartEvent(config));
 
         // Disable cache if disabled in the congif
-        if (!config.cacheStandardFunctionResults) {
+        if (config.cacheStandardFunctionResults) {
+            EnvironmentCache.enableCache();
+        } else {
             EnvironmentCache.disableCache();
         }
 


### PR DESCRIPTION
Hello,

1)
I think I have identified bug where enabling/disabling the cache was actually inverted... You have variable isStandardFunctionCacheDisabled = false;
and then you call 
cacheFunctionCall(isStandardFunctionCacheDisabled, env, function, result);

But this method has Boolean **shouldCache**
```
private static void cacheFunctionCall(
        Boolean shouldCache,
        Environment env,
        Expr.FunctionCall function,
        Object result
    )
```

So if you call the method with isStandardFunctionCacheDisabled=false, it actually says shouldCache = false, therefore the caching is disabled. I would honestly rename it, I can see where this bug could come from :D Quickfix I inverted the boolean value on calling the method. 

2) Because the variable isStandardFunctionCacheDisabled is static, disabling or enabling the cache in the same transaction in single call will influence calling Evaluator in other places, therefore for each evaluate I am now explicitly enabling/disabling the caching.
I was not sure if we should also reset the cache when it gets disabled or not, that I will leave open for now.  